### PR TITLE
Changed credits page text color back to Cyan

### DIFF
--- a/HomeInvaders/CreditsPage.cs
+++ b/HomeInvaders/CreditsPage.cs
@@ -10,7 +10,7 @@ namespace HomeInvaders
 	{
 		public static void ShowCredits()
 		{
-			Console.ForegroundColor = ConsoleColor.Blue; 
+			Console.ForegroundColor = ConsoleColor.Cyan; 
 
 			FileReader.ReadFile("Images\\Credits.txt");
 


### PR DESCRIPTION
Blue text with black background is hard to read. Simply changing color of the credits page text back to its original color of "Cyan". :smile: 